### PR TITLE
Rename el_client.el to xelb-gen and make it a proper script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-PROTO_PATH := ../xcb-proto/src
-
-EMACS_BIN := emacs -Q
+PROTO_PATH := /usr/share/xcb
 
 EXTENSIONS := bigreq composite damage dpms dri2 dri3 ge glx present randr \
 record render res screensaver shape shm sync xc_misc xevie xf86dri \
@@ -13,7 +11,7 @@ all: clean $(LIBS)
 
 xcb-%.el: $(PROTO_PATH)/%.xml
 	@echo -n "\n"Generating $@...
-	@$(EMACS_BIN) --script ./el_client.el $< > $@
+	@./xelb-gen $< > $@
 
 $(EXT_LIBS): xcb-xproto.el
 

--- a/xelb-gen
+++ b/xelb-gen
@@ -1,4 +1,5 @@
-;;; el_client.el --- XELB Code Generator  -*- lexical-binding: t -*-
+#!/usr/bin/env -S emacs -Q --script
+;;; xelb-gen --- XELB Code Generator  -*- lexical-binding: t; no-byte-compile: t -*-
 
 ;; Copyright (C) 2015-2024 Free Software Foundation, Inc.
 
@@ -21,7 +22,7 @@
 
 ;;; Commentary:
 
-;; 'el_client' is responsible for converting XCB XML description files into
+;; 'xelb-gen' is responsible for converting XCB XML description files into
 ;; Elisp libraries.  Here are a few design guidelines:
 ;; + The generated codes should be human-readable and conform to the Elisp
 ;;   coding conventions.  Names mentioned in X specifications are preferred.
@@ -726,4 +727,4 @@ The `combine-adjacent' attribute is simply ignored."
   (require 'xcb-types)
   (xelb-parse (car argv)))
 
-;;; el_client.el ends here
+;;; xelb-gen ends here


### PR DESCRIPTION
* el_client.el -> xelb-gen: Moved, marked executable, annotated with an emacs script shebang header, and marked as no-byte-compile.
* Makefile: Execute xelb-gen as a script.