### PR TITLE
Makefile dependencies and byte-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.elc
+# Makefile prerequisites.
+*.el.d
 *-pkg.el
 *-autoloads.el

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 PROTO_PATH := /usr/share/xcb
 
+ifeq ($(shell ! test -d $(PROTO_PATH) && echo ok),ok)
+  $(warning Please set `PROTO_PATH` to the path to the XCB protocol definitions):
+  $(warning make $(MFLAGS) $(MAKEOVERRIDES) $(MAKECMDGOALS) `PROTO_PATH=/opt/X11/...`)
+  $(error Could not find directory `$(PROTO_PATH)`)
+endif
+
 EXTENSIONS := bigreq composite damage dbe dpms dri2 dri3 ge glx present randr \
 record render res screensaver shape shm sync xc_misc xevie xf86dri \
 xf86vidmode xfixes xinerama xinput xkb xprint xselinux xtest xvmc xv
@@ -13,59 +19,64 @@ ELS = $(ELLS) $(ELGS)
 ELCS = $(ELS:.el=.elc) xelb-gen.elc
 
 .PHONY: all
-all: $(ELCS)
+all: compile generate
 
 xcb-%.el: $(PROTO_PATH)/%.xml
-	@echo -n "\n"Generating $@...
+	@printf '%s\n' 'Generating $@...'
 	@./xelb-gen $< > $@
 
-# Dependencies needed for generating.
-$(ELXS): xcb-xproto.el
-xcb-composite.el: xcb-xfixes.el
-xcb-cursor.el: xcb-render.el
-xcb-damage.el: xcb-xfixes.el
-xcb-present.el: xcb-randr.el xcb-xfixes.el xcb-sync.el
-xcb-randr.el: xcb-render.el
-xcb-xfixes.el: xcb-render.el xcb-shape.el
-xcb-xinput.el: xcb-xfixes.el
-xcb-xv.el: xcb-shm.el
-xcb-xvmc.el: xcb-xv.el
-
-# Generate an intermediate .el file from the xelb-gen script so that
-# byte-compiling rules below apply.  This file will be deleted after the .elc is
-# created.
+# Generate an intermediate `.el` file from the xelb-gen script so that
+# byte-compiling rules below apply.  This file will be deleted after the `.elc`
+# is created.
 .INTERMEDIATE: xelb-gen.el
 xelb-gen.el: xelb-gen
 	cp $< $@
 
+# Dependencies needed for generating.
+# We generate makefile fragments by grepping the `<import>`s in the `.xml`
+# protocol definitions.
+# See https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html .
+ELGDS=$(ELGS:.el=.el.d)
+$(ELGDS): xcb-%.el.d: $(PROTO_PATH)/%.xml
+	@printf "Inferring dependencies for $<\n"
+	@{ IMPORTS=$$(grep '<import>' $< | sed -E -e 's,^[[:space:]]*<import>([^<]+)</import>,xcb-\1,' | tr '\n' ' '); \
+	   test -n "$$IMPORTS" && printf '%s' 'xcb-$*.el:' && printf ' %s.el' $$IMPORTS && printf '\n'; \
+	   test -n "$$IMPORTS" && printf '%s' 'xcb-$*.elc:' && printf ' %s.elc' $$IMPORTS && printf '\n'; \
+	   true; \
+	} >$@
+# All generated `.el` files require `xcb-types.el`.
+$(ELGS): xcb-types.el
+$(ELGS:.el=.elc): xcb-types.elc
+
 # Dependencies needed for byte-compiling.
-xcb-cursor.elc: xcb-render.elc xcb.elc
-xcb-ewmh.elc: xcb.elc xcb-icccm.elc xcb.elc
-xcb-icccm.elc: xcb.elc
-xcb-keysyms.elc: xcb.elc xcb-xkb.elc
-xcb-renderutil.elc: xcb.elc xcb-render.elc
-xcb-systemtray.elc: xcb-ewmh.elc xcb.elc
-xcb-types.elc: xcb-debug.elc
-xcb-xembed.elc: xcb-icccm.elc
-xcb-xim.elc: xcb-types.elc xcb-xlib.elc
-xcb-xsettings.elc: xcb-icccm.elc xcb-types.elc
-xcb.elc: xcb-xproto.elc xcb-xkb.elc
-xelb.elc: xcb.elc
-$(ELXS:.el=.elc): xcb-xproto.elc xcb-types.elc
-xcb-composite.elc: xcb-xfixes.elc
-xcb-damage.elc: xcb-xfixes.elc
-xcb-present.elc: xcb-randr.elc xcb-xfixes.elc xcb-sync.elc
-xcb-randr.elc: xcb-render.elc
-xcb-xfixes.elc: xcb-render.elc xcb-shape.elc
-xcb-xinput.elc: xcb-xfixes.elc
-xcb-xv.elc: xcb-shm.elc
-xcb-xvmc.elc: xcb-xv.elc
-xelb-gen.elc: xcb-types.elc
+# We grep the `require`s in non-generated `.el` files.
+ELLDS=$(ELLS:.el=.el.d)
+$(ELLDS): %.el.d: %.el
+	@printf "Inferring dependencies for $<\n"
+	@{ printf '%s' '$*.elc: '; \
+	   grep "require 'xcb" $< | \
+	   sed -E -e "s,.*\(require '([^)]+)\).*,\1.elc," | \
+	   tr '\n' ' '; \
+	   printf '\n'; \
+	} >$@
+
+# This is a small crutch: we want to avoid generating the `.el.d`s (which means
+# parsing the XML and generating the corresponding `.el`s) in order to clean.
+ifneq ($(MAKECMDGOALS),clean)
+include $(ELLDS)
+include $(ELGDS)
+endif
 
 %.elc: %.el
 	@printf "Compiling $<\n"
-	emacs --batch -Q -L . -f batch-byte-compile $<
+	@emacs --batch -Q -L . -f batch-byte-compile $<
+
+.PHONY: compile
+compile: $(ELCS)
+
+.PHONY: generate
+generate: $(ELGS)
 
 .PHONY: clean
 clean:
-	@rm -vf $(ELGS) $(ELCS)
+	@rm -vf $(ELGS) $(ELLDS) $(ELCS) $(ELGDS)

--- a/xelb-gen
+++ b/xelb-gen
@@ -180,6 +180,7 @@ an `xelb-auto-padding' attribute."
   "Parse an XCB protocol description file FILE (XML)."
   (let ((pp-escape-newlines nil)        ;do not escape newlines
         (pp-default-function 'pp-28)    ;avoid unecessary churn
+        (load-prefer-newer 't)          ;avoid loading outdated bytecode
         result header)
     (with-temp-buffer
       (insert-file-contents file)


### PR DESCRIPTION
I'm just posting the makefile I use to see byte-compilation warnings.  Is this 

* The dependencies allow parallel making (`make -jN`).
* I like the byte-compilation warnings on xelb-gen.  This implies creating the `.elc`. (Maybe that's not necessary?)

This is meant to be applied after #4.