### PR TITLE
Fix lint error from `make-network-process` call

### DIFF
--- a/xcb.el
+++ b/xcb.el
@@ -186,7 +186,8 @@
                                                 socket)))
       (setq display (frame-parameter nil 'display)
             socket (xcb:display->socket display)))
-    (let* ((process (make-network-process :name "XELB" :remote socket))
+    (let* ((process (make-network-process :name "XELB" :family 'local
+                                          :service socket))
            (auth (if auth-info auth-info (xcb:create-auth-info)))
            (connection (make-instance 'xcb:connection
                                       :process process :display display


### PR DESCRIPTION
The byte-compiler doesn't like the lack of a :service parameter. It works just fine, but we might as well make it happy. It looks like upstream Emacs source code uses `(... :family 'local :service socket)` as well.

* xcb.el (xcb:connect-to-socket): Use :service & :family instead of :remote to avoid the byte-compiler warning.