### PR TITLE
Fix lint errors

### DIFF
--- a/xcb-keysyms.el
+++ b/xcb-keysyms.el
@@ -39,7 +39,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl-lib))
+(require 'cl-lib)
 
 (require 'xcb)
 (require 'xcb-xkb)
@@ -149,7 +149,7 @@ This method must be called before using any other method in this module."
                        :autoCtrlsValues 0))))
 
 (cl-defmethod xcb:keysyms:-on-NewKeyboardNotify ((obj xcb:connection) data)
-  "Handle 'NewKeyboardNotify' event."
+  "Handle a \\='NewKeyboardNotify' event."
   (let ((device-id (xcb:-get-extra-plist obj 'keysyms 'device-id))
         (callback (xcb:-get-extra-plist obj 'keysyms 'callback))
         (obj1 (make-instance 'xcb:xkb:NewKeyboardNotify))
@@ -182,7 +182,7 @@ This method must be called before using any other method in this module."
         (funcall callback)))))
 
 (cl-defmethod xcb:keysyms:-on-MapNotify ((obj xcb:connection) data)
-  "Handle 'MapNotify' event."
+  "Handle \\='MapNotify' event."
   (let ((device-id (xcb:-get-extra-plist obj 'keysyms 'device-id))
         (callback (xcb:-get-extra-plist obj 'keysyms 'callback))
         (obj1 (make-instance 'xcb:xkb:MapNotify))

--- a/xcb.el
+++ b/xcb.el
@@ -52,7 +52,8 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl-lib))
+(require 'cl-lib)
+
 (require 'xcb-xproto)
 
 (defvar xcb:connection-timeout 3 "Connection timeout.")
@@ -418,9 +419,8 @@ Concurrency is disabled as it breaks the orders of errors, replies and events."
               (setq data (aref event 1)
                     synthetic (aref event 2))
               (dolist (listener (aref event 0))
-                (unwind-protect
-                    (xcb-debug:backtrace-on-error
-                     (funcall listener data synthetic))))))
+                (xcb-debug:backtrace-on-error
+                 (funcall listener data synthetic)))))
         (cl-decf event-lock)))))
 
 (cl-defmethod xcb:disconnect ((obj xcb:connection))


### PR DESCRIPTION
* xcb-keysyms.el, xcb.el: Import `cl-lib` at runtime for macros like `cl-incf`.
* xcb-keysyms.el: Fix documentation quoting.
* xcb.el (xcb:+event, xcb:-connection-filter): Avoid deprecated `lax-plist-` functions.
  (xcb:-process-events): Remove unused `unwind-protect`.