### PR TITLE
Fix warnings cl-lib and lax-plist warnings

### DIFF
--- a/xcb-types.el
+++ b/xcb-types.el
@@ -48,7 +48,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl-lib))
+(require 'cl-lib) ; cl-coerce
 (require 'cl-generic)
 (require 'eieio)
 (require 'xcb-debug)


### PR DESCRIPTION
Please have a look especially at the `lax-plist-*` ones.