### PR TITLE
Fix assertion

### DIFF
--- a/xcb-icccm.el
+++ b/xcb-icccm.el
@@ -272,9 +272,9 @@ This method automatically encodes the data (which is a string)."
   "Fill in the fields in the reply of an ICCCM GetProperty (single-valued)
 request OBJ according to BYTE-ARRAY."
   (let ((retval (cl-call-next-method obj byte-array)))
-    (with-slots (value) obj
+    (with-slots (value value-len) obj
       (when value
-        (cl-assert (= 1 (length value)))
+        (cl-assert (= value-len (length value)))
         (setf value (elt value 0))))
     retval))
 


### PR DESCRIPTION
* xcb-icccm.el (xcb:unmarshal) assert value according to value-len

----

```
(xcb:+request+reply connection
                   (make-instance 'xcb:ewmh:get-_NET_ACTIVE_WINDOW
                                  :window root)))

```
Error message:

`Debugger entered--Lisp error: (cl-assertion-failed ((= 1 (length value)) nil))`

Some debugging:

```
(slot-value connection 'reply-plist)
→ (96 (xcb:ewmh:get-_NET_ACTIVE_WINDOW [1 32 96 0 2 0 0 0 33 0 0 0 0 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 154 1 64 5 0 0 0 0]))

(setq reply-plist (slot-value connection 'reply-plist))
→ (96 (xcb:ewmh:get-_NET_ACTIVE_WINDOW [1 32 96 0 2 0 0 0 33 0 0 0 ...]))

(setq reply-data (plist-get reply-plist 96))
→ (xcb:ewmh:get-_NET_ACTIVE_WINDOW [1 32 96 0 2 0 0 0 33 0 0 0 ...])

(setq class-name (xcb:-request-class->reply-class (car reply-data)))
→ xcb:ewmh:get-_NET_ACTIVE_WINDOW~reply

(setq reply-data (cadr reply-data)
      replies (make-instance class-name))

(xcb:unmarshal replies reply-data)
→ error

(cl-assert (= 1 (length (slot-value replies 'value))))
→ error

(length (slot-value replies 'value))
→ 2
(slot-value replies 'type)
→ 33
(slot-value replies 'format)
→ 32
(slot-value replies 'bytes-after)
→ 0
(slot-value replies 'value-len)
→ 2
(slot-value replies 'value)
→ [88080794 0]
```