### PR TITLE
Require subr-x on Emacs less than 29

### DIFF
--- a/xcb-types.el
+++ b/xcb-types.el
@@ -54,6 +54,10 @@
 (require 'eieio)
 (require 'xcb-debug)
 
+;; Require subr-x on Emacs < 29 for when-let*, it has since been moved to
+;; subr (autoloaded).
+(eval-when-compile (when (< emacs-major-version 29) (require 'subr-x)))
+
 (define-minor-mode xcb:debug
   "Debug-logging enabled if non-nil."
   :group 'debug


### PR DESCRIPTION
Before Emacs 29, when-let (and friends) lived in subr-x, which isn't autoloaded.

* xcb-types.el: require subr-x before Emacs 29 (fixes emacs-exwm/exwm#130).