### PR TITLE
Support valve's invalid UTF-8 text-encoding atom

### DIFF
--- a/xcb-icccm.el
+++ b/xcb-icccm.el
@@ -47,9 +47,12 @@
 
 (eval-and-compile
   (defconst xcb:icccm:-atoms
-    '(UTF8_STRING COMPOUND_TEXT TEXT C_STRING MANAGER
-                  WM_PROTOCOLS WM_TAKE_FOCUS WM_DELETE_WINDOW
-                  WM_STATE WM_CHANGE_STATE WM_S0)
+    '(;; Standard atoms
+      UTF8_STRING COMPOUND_TEXT TEXT C_STRING MANAGER
+      WM_PROTOCOLS WM_TAKE_FOCUS WM_DELETE_WINDOW
+      WM_STATE WM_CHANGE_STATE WM_S0
+      ;; Illegal alias of UTF8_STRING used by Valve's Steam.
+      UTF-8)
     "Atoms involved in ICCCM.")
 
   (dolist (atom xcb:icccm:-atoms)
@@ -222,11 +225,14 @@ This method automatically decodes the value (as string)."
         (setf value
               (decode-coding-string
                (apply #'unibyte-string (append value nil))
-               (cond ((= type xcb:Atom:UTF8_STRING) 'utf-8)
+               (cond ((or (= type xcb:Atom:UTF8_STRING)
+                          (= type xcb:Atom:UTF-8))
+                      'utf-8)
                      ((= type xcb:Atom:STRING) 'iso-latin-1)
                      ((= type xcb:Atom:COMPOUND_TEXT)
                       'compound-text-with-extensions)
-                     ((or (eq type xcb:Atom:TEXT) (eq type xcb:Atom:C_STRING))
+                     ((or (= type xcb:Atom:TEXT)
+                          (= type xcb:Atom:C_STRING))
                       'no-conversion)
                      (t (error "[XELB:ICCCM] Unsupported encoding: %s (%d)"
                                (x-get-atom-name type) type)))))))


### PR DESCRIPTION
Valve uses this [1] to specify the window name and they haven't fixed it in over a year. I hate shipping hacks to support broken software, but it's better than leaving it broken on principle.

* xcb-icccm.el (xcb:icccm:-atoms): add the UTF-8 atom. (xcb:unmarshal): allow the UTF-8 atom as an alias for UTF8_STRING when getting (but not when setting) properties.

[1]: https://github.com/ValveSoftware/steam-for-linux/issues/10854

fixes emacs-exwm/exwm#140