### PR TITLE
Add a new variant of xcb:unmarshal that returns an object

### DIFF
--- a/xcb-keysyms.el
+++ b/xcb-keysyms.el
@@ -152,9 +152,8 @@ This method must be called before using any other method in this module."
   "Handle a \\='NewKeyboardNotify' event."
   (let ((device-id (xcb:-get-extra-plist obj 'keysyms 'device-id))
         (callback (xcb:-get-extra-plist obj 'keysyms 'callback))
-        (obj1 (make-instance 'xcb:xkb:NewKeyboardNotify))
+        (obj1 (xcb:unmarshal-new 'xcb:xkb:NewKeyboardNotify data))
         device updated)
-    (xcb:unmarshal obj1 data)
     (with-slots (deviceID oldDeviceID requestMajor requestMinor changed) obj1
       (if (= 0 (logand changed xcb:xkb:NKNDetail:DeviceID))
           (when (/= 0 (logand changed xcb:xkb:NKNDetail:Keycodes))
@@ -185,9 +184,8 @@ This method must be called before using any other method in this module."
   "Handle \\='MapNotify' event."
   (let ((device-id (xcb:-get-extra-plist obj 'keysyms 'device-id))
         (callback (xcb:-get-extra-plist obj 'keysyms 'callback))
-        (obj1 (make-instance 'xcb:xkb:MapNotify))
+        (obj1 (xcb:unmarshal-new 'xcb:xkb:MapNotify data))
         updated)
-    (xcb:unmarshal obj1 data)
     (with-slots (deviceID changed firstType nTypes firstKeySym nKeySyms) obj1
       ;; Ensure this event is for the current device.
       (when (/= 0 (logand changed xcb:xkb:MapPart:KeyTypes))

--- a/xcb-types.el
+++ b/xcb-types.el
@@ -916,6 +916,13 @@ The optional argument CTX is for <paramref>."
         (setf (slot-value obj (eieio-slot-descriptor-name slot)) (car tmp))))
     (slot-value obj '~size)))
 
+(defun xcb:unmarshal-new (type byte-array)
+  "Construct a new object of type TYPE and unmarshal BYTE-ARRAY into it.
+Return the new object."
+  (let ((obj (make-instance type)))
+    (xcb:unmarshal obj byte-array)
+    obj))
+
 
 
 (provide 'xcb-types)


### PR DESCRIPTION
Instead of having to write:

```elisp
(let* ((obj (let ((m (make-instance 'xcb:ClientMessage)))
              (xcb:unmarshal m raw-data)
              m))
       (type (slot-value obj 'type))
```

We can now write:

```elisp
(let* ((obj (xcb:unmarshal 'xcb:ClientMessage raw-data))
       (type (slot-value obj 'type))
```

We could also define a new method given that this is a bit of an abuse of generics (cc @minad). We'd just need to come up with a name for it (`xcb:make-unmarshal`, `xcb:unmarshal-instance`, `xcb:unmarshal-new`?).